### PR TITLE
Replace "/" -> "\" if windows in 'manager-bin' path

### DIFF
--- a/Asset/AbstractAssetManager.php
+++ b/Asset/AbstractAssetManager.php
@@ -17,6 +17,7 @@ use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\VersionParser;
 use Composer\Util\Filesystem;
 use Composer\Util\ProcessExecutor;
+use Composer\Util\Platform;
 use Foxy\Config\Config;
 use Foxy\Exception\RuntimeException;
 use Foxy\Fallback\FallbackInterface;
@@ -220,6 +221,11 @@ abstract class AbstractAssetManager implements AssetManagerInterface
     protected function buildCommand($defaultBin, $action, $command)
     {
         $bin = $this->config->get('manager-bin', $defaultBin);
+        
+        if (Platform::isWindows()) {
+            $bin = str_replace('/', DIRECTORY_SEPARATOR, $bin);
+        }
+
         $gOptions = trim($this->config->get('manager-options', ''));
         $options = trim($this->config->get('manager-'.$action.'-options', ''));
 

--- a/Asset/AbstractAssetManager.php
+++ b/Asset/AbstractAssetManager.php
@@ -221,13 +221,13 @@ abstract class AbstractAssetManager implements AssetManagerInterface
     protected function buildCommand($defaultBin, $action, $command)
     {
         $bin = $this->config->get('manager-bin', $defaultBin);
-        
-        if (Platform::isWindows()) {
-            $bin = str_replace('/', DIRECTORY_SEPARATOR, $bin);
-        }
 
         $gOptions = trim($this->config->get('manager-options', ''));
         $options = trim($this->config->get('manager-'.$action.'-options', ''));
+        
+        if (Platform::isWindows()) {
+            $bin = str_replace('/', '\\', $bin);
+        }
 
         return $bin.' '.$command
             .(empty($gOptions) ? '' : ' '.$gOptions)

--- a/Asset/AbstractAssetManager.php
+++ b/Asset/AbstractAssetManager.php
@@ -221,7 +221,6 @@ abstract class AbstractAssetManager implements AssetManagerInterface
     protected function buildCommand($defaultBin, $action, $command)
     {
         $bin = $this->config->get('manager-bin', $defaultBin);
-
         $gOptions = trim($this->config->get('manager-options', ''));
         $options = trim($this->config->get('manager-'.$action.'-options', ''));
         


### PR DESCRIPTION
Foxy has config option "manager-bin" and it's possible to define it in composer.json. If you use it it works good, if you are using package only on windows or *nix, however if you want to use it between OS'es, it's possible that you will have some problem. If you define your path like in windows f.e. `vendor\bin\npm` on linux this would not work. And linux path like `vendor/bin/npm` would rise similar problem in windows.

This pull request, if detects that composer runs on windows replaces all `/` with `\` in path. So, now it possible to write path in linux style that could work also on windows.

This can be useful when using foxy with such composer plugin like [nodejs-installer](https://packagist.org/packages/mouf/nodejs-installer) that installs node and npm in vendor folder.