### PR TITLE
Fix typo in config docs at composer-asset-dir

### DIFF
--- a/Resources/doc/config.md
+++ b/Resources/doc/config.md
@@ -317,7 +317,7 @@ You can define the custom path of the mock package of PHP library with the optio
 {
     "config": {
         "foxy": {
-            "manager-bin": "./my/mock/asset/path/of/project"
+            "composer-asset-dir": "./my/mock/asset/path/of/project"
         }
     }
 }


### PR DESCRIPTION
## Proposed Change

The sample JSON code doesn't match the config key for `config.foxy.composer-asset-dir`. Propose a fix for that here.

See https://github.com/fxpio/foxy/blob/master/Resources/doc/config.md#define-the-custom-path-of-the-mock-package-of-php-library