### PR TITLE
Change manager-timeout default to PHP_INT_MAX to fix compatibility with Composer 2.3+

### DIFF
--- a/Asset/AbstractAssetManager.php
+++ b/Asset/AbstractAssetManager.php
@@ -218,7 +218,7 @@ abstract class AbstractAssetManager implements AssetManagerInterface
         $this->io->write($info);
 
         $timeout = ProcessExecutor::getTimeout();
-        ProcessExecutor::setTimeout($this->config->get('manager-timeout'));
+        ProcessExecutor::setTimeout($this->config->get('manager-timeout', PHP_INT_MAX));
         $cmd = $updatable ? $this->getUpdateCommand() : $this->getInstallCommand();
         $res = (int) $this->executor->execute($cmd);
         ProcessExecutor::setTimeout($timeout);

--- a/Resources/doc/config.md
+++ b/Resources/doc/config.md
@@ -241,7 +241,7 @@ option `config.foxy.manager-update-options` [`string`, default: `null`].
 ### Define the execution timeout of the asset manager
 
 You can define the execution timeout of the asset manager with the
-option `config.foxy.manager-timeout` [`int`, default: `null`].
+option `config.foxy.manager-timeout` [`int`, default: `PHP_INT_MAX`].
 
 **Example:**
 ```json


### PR DESCRIPTION
This fixes #44.

Composer 2.3+ has made the parameter of ProcessExecutor::setTimeout an int value, so to mimic an unlimited timeout, we'll now use PHP_INT_MAX as the default value.